### PR TITLE
PEG-2095: Upgrade jackson to 2.15.0 to fix security vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file, which loose
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Security
+- Upgrade jackson to version 2.15.0 to fix security vulnerabilities:
+    - **CVE-2022-42003** Detail: https://cwe.mitre.org/data/definitions/502.html
+    - **CVE-2025-52999** Detail: https://cwe.mitre.org/data/definitions/121.html
+    - **CVE-2022-42004** Detail: https://cwe.mitre.org/data/definitions/400.html
+    - **CCVE-2025-49128** Detail: https://cwe.mitre.org/data/definitions/209.html
 
 # [17.103.0] - 2025-07-16
 ### Changed

--- a/framework-api/framework-api-core/src/main/java/uk/gov/justice/services/core/featurecontrol/domain/Feature.java
+++ b/framework-api/framework-api-core/src/main/java/uk/gov/justice/services/core/featurecontrol/domain/Feature.java
@@ -2,12 +2,16 @@ package uk.gov.justice.services.core.featurecontrol.domain;
 
 import java.util.Objects;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class Feature {
 
     private final String featureName;
     private final boolean enabled;
 
-    public Feature(final String featureName, final boolean enabled) {
+    @JsonCreator
+    public Feature(@JsonProperty("feature_name") final String featureName, @JsonProperty("enabled") final boolean enabled) {
         this.featureName = featureName;
         this.enabled = enabled;
     }

--- a/framework-api/framework-api-core/src/main/java/uk/gov/justice/services/core/featurecontrol/domain/FeatureControl.java
+++ b/framework-api/framework-api-core/src/main/java/uk/gov/justice/services/core/featurecontrol/domain/FeatureControl.java
@@ -4,13 +4,14 @@ import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FeatureControl {
 
     private final List<Feature> features;
 
     @JsonCreator
-    public FeatureControl(final List<Feature> features) {
+    public FeatureControl(@JsonProperty("feature") final List<Feature> features) {
         this.features = features;
     }
 

--- a/framework-utilities/test-utils/test-utils-framework-api/src/test/java/uk/gov/justice/services/test/utils/framework/api/JsonObjectConvertersFactoryTest.java
+++ b/framework-utilities/test-utils/test-utils-framework-api/src/test/java/uk/gov/justice/services/test/utils/framework/api/JsonObjectConvertersFactoryTest.java
@@ -66,10 +66,10 @@ public class JsonObjectConvertersFactoryTest {
     private void checkSetUpCorrectly(final ObjectMapper objectMapper) {
         final Set<String> registeredModuleTypes = getValueOfField(objectMapper, "_registeredModuleTypes", Set.class);
 
-        assertThat(registeredModuleTypes, hasItem("com.fasterxml.jackson.datatype.jsr310.JavaTimeModule"));
+        assertThat(registeredModuleTypes, hasItem("jackson-datatype-jsr310"));
         assertThat(registeredModuleTypes, hasItem("com.fasterxml.jackson.datatype.jdk8.Jdk8Module"));
-        assertThat(registeredModuleTypes, hasItem("com.fasterxml.jackson.module.paramnames.ParameterNamesModule"));
-        assertThat(registeredModuleTypes, hasItem("uk.gov.justice.services.common.converter.jackson.jsr353.InclusionAwareJSR353Module"));
+        assertThat(registeredModuleTypes, hasItem("jackson-module-parameter-names"));
+        assertThat(registeredModuleTypes, hasItem("jackson-datatype-jsr353"));
         assertThat(registeredModuleTypes, hasItem("uk.gov.justice.services.common.converter.jackson.additionalproperties.AdditionalPropertiesModule"));
         assertThat(registeredModuleTypes, hasItem("uk.gov.justice.services.common.converter.jackson.integerenum.IntegerEnumModule"));
     }

--- a/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/ObjectMapperProducer.java
+++ b/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/ObjectMapperProducer.java
@@ -4,6 +4,7 @@ import static com.fasterxml.jackson.annotation.JsonCreator.Mode.PROPERTIES;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_ABSENT;
 import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.fasterxml.jackson.databind.DeserializationFeature.READ_ENUMS_USING_TO_STRING;
+import static com.fasterxml.jackson.databind.MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_WITH_ZONE_ID;
 import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_ENUMS_USING_TO_STRING;
@@ -23,10 +24,11 @@ import java.time.ZonedDateTime;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
 
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.ZonedDateTimeSerializer;
@@ -43,13 +45,32 @@ public class ObjectMapperProducer {
         return configureObjectMapper(new ObjectMapper());
     }
 
-    public ObjectMapper objectMapperWith(final JsonFactory jsonFactory) {
-        return configureObjectMapper(new ObjectMapper(jsonFactory));
-    }
 
     public ObjectMapper yamlObjectMapper() {
-        return configureObjectMapper(new ObjectMapper(new YAMLFactory()))
-                .setPropertyNamingStrategy(PropertyNamingStrategy.CAMEL_CASE_TO_LOWER_CASE_WITH_UNDERSCORES);
+
+        return new ObjectMapper(new YAMLFactory())
+                .registerModule(javaTimeModuleWithFormattedDateTime())
+                .registerModule(new Jdk8Module())
+                .registerModule(new InclusionAwareJSR353Module())
+                .registerModule(new AdditionalPropertiesModule())
+                .registerModule(new IntegerEnumModule())
+                .configure(WRITE_DATES_AS_TIMESTAMPS, false)
+                .configure(WRITE_DATES_WITH_ZONE_ID, false)
+                .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(WRITE_NULL_MAP_VALUES, false)
+                .setTimeZone(getTimeZone(UTC))
+                .enable(WRITE_ENUMS_USING_TO_STRING)
+                .enable(READ_ENUMS_USING_TO_STRING)
+                .enable(ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .setConstructorDetector(USE_PROPERTIES_BASED)
+                .setSerializationInclusion(NON_ABSENT)
+                ;
+    }
+
+    private JavaTimeModule javaTimeModuleWithFormattedDateTime() {
+        final JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addSerializer(ZonedDateTime.class, new ZonedDateTimeSerializer(ofPattern(ISO_8601)));
+        return javaTimeModule;
     }
 
     private ObjectMapper configureObjectMapper(final ObjectMapper objectMapper) {
@@ -68,12 +89,7 @@ public class ObjectMapperProducer {
                 .enable(WRITE_ENUMS_USING_TO_STRING)
                 .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .enable(READ_ENUMS_USING_TO_STRING)
-                .setConstructorDetector(USE_PROPERTIES_BASED);
-    }
-
-    private JavaTimeModule javaTimeModuleWithFormattedDateTime() {
-        final JavaTimeModule javaTimeModule = new JavaTimeModule();
-        javaTimeModule.addSerializer(ZonedDateTime.class, new ZonedDateTimeSerializer(ofPattern(ISO_8601)));
-        return javaTimeModule;
+                .setConstructorDetector(USE_PROPERTIES_BASED)
+                ;
     }
 }

--- a/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/integerenum/IntegerEnumBeanDeserializerModifier.java
+++ b/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/integerenum/IntegerEnumBeanDeserializerModifier.java
@@ -22,7 +22,7 @@ public class IntegerEnumBeanDeserializerModifier extends BeanDeserializerModifie
 
         final Class<Enum<?>> enumClass = (Class<Enum<?>>) type.getRawClass();
 
-        final EnumResolver enumResolver = constructFor(enumClass, nopInstance());
+        final EnumResolver enumResolver = constructFor(config, enumClass);
 
         return new IntegerEnumDeserializer(
                 enumResolver,

--- a/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/integerenum/IntegerEnumDeserializer.java
+++ b/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/integerenum/IntegerEnumDeserializer.java
@@ -21,7 +21,7 @@ public class IntegerEnumDeserializer extends EnumDeserializer {
 
     public IntegerEnumDeserializer(final EnumResolver enumResolver,
                                    final EnumObjectUtil enumObjectUtil) {
-        super(enumResolver);
+        super(enumResolver, true);
         this.enumerations = asList(enumResolver.getRawEnums());
         this.enumObjectUtil = enumObjectUtil;
     }

--- a/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/yaml/YamlParser.java
+++ b/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/yaml/YamlParser.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.services.yaml;
 
+import static com.fasterxml.jackson.databind.cfg.ConstructorDetector.USE_PROPERTIES_BASED;
 import static java.lang.String.format;
 
 import uk.gov.justice.services.common.converter.jackson.ObjectMapperProducer;
@@ -9,6 +10,7 @@ import java.net.URL;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 public class YamlParser {
 

--- a/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/common/converter/JsonObjectToObjectConverterTest.java
+++ b/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/common/converter/JsonObjectToObjectConverterTest.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.services.common.converter;
 
+import static java.time.ZoneOffset.UTC;
+import static java.time.format.DateTimeFormatter.ofPattern;
 import static java.util.UUID.randomUUID;
 import static javax.json.Json.createObjectBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -9,12 +11,14 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.mockito.Mockito.doThrow;
+import static uk.gov.justice.services.common.converter.ZonedDateTimes.ISO_8601;
 
 import uk.gov.justice.services.common.converter.jackson.ObjectMapperProducer;
 
 import java.io.IOException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
 
@@ -64,23 +68,33 @@ public class JsonObjectToObjectConverterTest {
     @Test
     public void shouldConvertToPojoWithUTCDateTime() throws Exception {
 
-        assertThat(jsonObjectToObjectConverter
-                        .convert(Json.createObjectBuilder().add("dateTime", "2016-07-25T13:09:01.0+00:00").build(),
-                                PojoWithDateTime.class).getDateTime(),
-                equalTo(ZonedDateTime.of(2016, 7, 25, 13, 9, 1, 0, ZoneId.of("UTC"))));
-        assertThat(jsonObjectToObjectConverter
-                        .convert(Json.createObjectBuilder().add("dateTime", "2016-07-25T13:09:01.0Z").build(),
-                                PojoWithDateTime.class).getDateTime(),
-                equalTo(ZonedDateTime.of(2016, 7, 25, 13, 9, 1, 0, ZoneId.of("UTC"))));
-        assertThat(jsonObjectToObjectConverter
-                        .convert(Json.createObjectBuilder().add("dateTime", "2016-07-25T13:09:01Z").build(),
-                                PojoWithDateTime.class).getDateTime(),
-                equalTo(ZonedDateTime.of(2016, 7, 25, 13, 9, 1, 0, ZoneId.of("UTC"))));
-        assertThat(jsonObjectToObjectConverter
-                        .convert(Json.createObjectBuilder().add("dateTime", "2016-07-25T16:09:01.0+03:00").build(),
-                                PojoWithDateTime.class).getDateTime(),
-                equalTo(ZonedDateTime.of(2016, 7, 25, 13, 9, 1, 0, ZoneId.of("UTC"))));
+        final ZonedDateTime expectedDateTime = ZonedDateTime.of(2016, 7, 25, 13, 9, 1, 0, UTC);
 
+        final PojoWithDateTime pojoWithDateTime_1 = jsonObjectToObjectConverter.convert(
+                createObjectBuilder()
+                        .add("dateTime", "2016-07-25T13:09:01.0+00:00")
+                        .build(),
+                PojoWithDateTime.class);
+        final PojoWithDateTime pojoWithDateTime_2 = jsonObjectToObjectConverter
+                .convert(createObjectBuilder()
+                                .add("dateTime", "2016-07-25T13:09:01.0Z")
+                                .build(),
+                        PojoWithDateTime.class);
+        final PojoWithDateTime pojoWithDateTime_3 = jsonObjectToObjectConverter
+                .convert(createObjectBuilder()
+                                .add("dateTime", "2016-07-25T16:09:01.0+03:00")
+                                .build(),
+                        PojoWithDateTime.class);
+        final PojoWithDateTime pojoWithDateTime_4 = jsonObjectToObjectConverter
+                .convert(createObjectBuilder()
+                                .add("dateTime", "2016-07-25T13:09:01.000Z")
+                                .build(),
+                        PojoWithDateTime.class);
+
+        assertThat(pojoWithDateTime_1.getDateTime(), equalTo(expectedDateTime));
+        assertThat(pojoWithDateTime_2.getDateTime(), equalTo(expectedDateTime));
+        assertThat(pojoWithDateTime_3.getDateTime(), equalTo(expectedDateTime));
+        assertThat(pojoWithDateTime_4.getDateTime(), equalTo(expectedDateTime));
     }
 
     @Test
@@ -88,7 +102,7 @@ public class JsonObjectToObjectConverterTest {
 
         final UUID uuid = randomUUID();
 
-        final JsonObject jsonObject = Json.createObjectBuilder().add("id", uuid.toString()).build();
+        final JsonObject jsonObject = createObjectBuilder().add("id", uuid.toString()).build();
 
         doThrow(JsonProcessingException.class).when(objectMapper).writeValueAsString(jsonObject);
 
@@ -119,10 +133,10 @@ public class JsonObjectToObjectConverterTest {
                 .add(ATTRIBUTE_1)
                 .add(ATTRIBUTE_2).build();
 
-        return Json.createObjectBuilder()
+        return createObjectBuilder()
                 .add("id", ID.toString())
                 .add("name", NAME)
-                .add("internalPojo", Json.createObjectBuilder()
+                .add("internalPojo", createObjectBuilder()
                         .add("internalId", INTERNAL_ID.toString())
                         .add("internalName", INTERNAL_NAME).build())
                 .add("attributes", array).build();
@@ -135,7 +149,7 @@ public class JsonObjectToObjectConverterTest {
         private List<String> attributes;
         private InternalPojo internalPojo;
 
-        public Pojo () {
+        public Pojo() {
 
         }
 
@@ -203,7 +217,7 @@ public class JsonObjectToObjectConverterTest {
     public static class SingleArgumentConstructorPojo {
         private UUID id;
 
-        public SingleArgumentConstructorPojo (UUID id) {
+        public SingleArgumentConstructorPojo(UUID id) {
             this.id = id;
         }
 

--- a/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/YamlParserTest.java
+++ b/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/YamlParserTest.java
@@ -20,6 +20,10 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import org.junit.jupiter.api.Test;
 
 public class YamlParserTest {
@@ -49,8 +53,7 @@ public class YamlParserTest {
         assertThat(events_1.get(1).getName(), is("example.recipe-deleted"));
         assertThat(events_1.get(1).getSchemaUri(), is("http://justice.gov.uk/json/schemas/domains/example/example.recipe-deleted.json"));
     }
-
-
+    
     @Test
     public void shouldParseSubscriptionPathAsSubscriptionDescriptorDef() throws Exception {
 

--- a/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/Event.java
+++ b/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/Event.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.services.yaml.subscriptiondescriptor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Event {
 
@@ -8,7 +9,7 @@ public class Event {
     private final String schemaUri;
 
     @JsonCreator
-    public Event(final String name, final String schemaUri) {
+    public Event(@JsonProperty("name") final String name, @JsonProperty("schema_uri") final String schemaUri) {
         this.name = name;
         this.schemaUri = schemaUri;
     }
@@ -19,5 +20,13 @@ public class Event {
 
     public String getSchemaUri() {
         return schemaUri;
+    }
+
+    @Override
+    public String toString() {
+        return "Event{" +
+               "name='" + name + '\'' +
+               ", schemaUri='" + schemaUri + '\'' +
+               '}';
     }
 }

--- a/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/Subscription.java
+++ b/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/Subscription.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Subscription {
 
@@ -13,10 +14,10 @@ public class Subscription {
     private final String prioritisation;
 
     @JsonCreator
-    public Subscription(final String name,
-                        final List<Event> events,
-                        final String eventSourceName,
-                        final String prioritisation) {
+    public Subscription(@JsonProperty("name") final String name,
+                        @JsonProperty("events") final List<Event> events,
+                        @JsonProperty("event_source_name") final String eventSourceName,
+                        @JsonProperty("prioritisation") final String prioritisation) {
         this.name = name;
         this.events = events;
         this.eventSourceName = eventSourceName;
@@ -53,5 +54,15 @@ public class Subscription {
     @Override
     public int hashCode() {
         return Objects.hash(name, events,prioritisation, eventSourceName);
+    }
+
+    @Override
+    public String toString() {
+        return "Subscription{" +
+               "name='" + name + '\'' +
+               ", events=" + events +
+               ", eventSourceName='" + eventSourceName + '\'' +
+               ", prioritisation='" + prioritisation + '\'' +
+               '}';
     }
 }

--- a/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/SubscriptionDescriptorDef.java
+++ b/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/SubscriptionDescriptorDef.java
@@ -1,18 +1,28 @@
 package uk.gov.justice.services.yaml.subscriptiondescriptor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 public class SubscriptionDescriptorDef {
 
+    @JsonProperty("subscriptions_descriptor")
     private final SubscriptionsDescriptor subscriptionsDescriptor;
 
     @JsonCreator
-    public SubscriptionDescriptorDef(final SubscriptionsDescriptor subscriptionsDescriptor) {
+    public SubscriptionDescriptorDef(@JsonProperty("subscriptions-descriptor") final SubscriptionsDescriptor subscriptionsDescriptor) {
         this.subscriptionsDescriptor = subscriptionsDescriptor;
     }
 
     public SubscriptionsDescriptor getSubscriptionsDescriptor() {
         return subscriptionsDescriptor;
+    }
+
+    @Override
+    public String toString() {
+        return "SubscriptionDescriptorDef{" +
+               "subscriptionsDescriptor=" + subscriptionsDescriptor +
+               '}';
     }
 }
 

--- a/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/SubscriptionsDescriptor.java
+++ b/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/yaml/subscriptiondescriptor/SubscriptionsDescriptor.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SubscriptionsDescriptor {
 
@@ -13,7 +14,11 @@ public class SubscriptionsDescriptor {
     private final List<Subscription> subscriptions;
 
     @JsonCreator
-    public SubscriptionsDescriptor(final String specVersion, final String service, final String serviceComponent, final List<Subscription> subscriptions) {
+    public SubscriptionsDescriptor(
+            @JsonProperty("spec_version") final String specVersion,
+            @JsonProperty("service") final String service,
+            @JsonProperty("service_component") final String serviceComponent,
+            @JsonProperty("subscription") final List<Subscription> subscriptions) {
         this.specVersion = specVersion;
         this.service = service;
         this.serviceComponent = serviceComponent;
@@ -51,4 +56,13 @@ public class SubscriptionsDescriptor {
         return subscriptions;
     }
 
+    @Override
+    public String toString() {
+        return "SubscriptionsDescriptor{" +
+               "specVersion='" + specVersion + '\'' +
+               ", service='" + service + '\'' +
+               ", serviceComponent='" + serviceComponent + '\'' +
+               ", subscriptions=" + subscriptions +
+               '}';
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,17 +36,16 @@
 
     <properties>
         <cpp.repo.name>framework-libraries</cpp.repo.name>
-        <maven-common-bom.version>17.103.1</maven-common-bom.version>
+        <maven-common-bom.version>17.104.0-M2-SNAPSHOT</maven-common-bom.version>
         <cucumber.reporting.plugin.version>2.0.0</cucumber.reporting.plugin.version>
         <framework-wiremock-service.version>17.0.1</framework-wiremock-service.version>
-        <file-service.version>17.103.1</file-service.version>
+        <file-service.version>17.103.2-SNAPSHOT</file-service.version>
 
         <!-- Fix me -->
         <openejb.version>8.0.13</openejb.version>
 
         <!-- Must be moved to parent-pom -->
         <maven-plugin-annotations.version>3.7.1</maven-plugin-annotations.version>
-
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Draft pull request to keep for reference:

Unfortunately upgrading the Jackson libraries we use conflicts with the version that wildfly 26 uses. We have 3 options.
- Don't upgrade and live with the security vulnerabilities
- Upgrade the Jackson modules in all our current wildfly deployments
- Upgrade Wildfly to a later version that uses a more secure version of Jackson

This pull request will not compile until these pull requests have been merged and released:
- https://github.com/hmcts/cp-maven-common-bom/pull/166
