### PR TITLE
Java 25 / WildFly 40 spike: cp-framework-libraries

### DIFF
--- a/annotation-validator/annotation-validator-core/pom.xml
+++ b/annotation-validator/annotation-validator-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.maven</groupId>
         <artifactId>annotation-validator</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/annotation-validator/annotation-validator-maven-plugin/pom.xml
+++ b/annotation-validator/annotation-validator-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.maven</groupId>
         <artifactId>annotation-validator</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/annotation-validator/pom.xml
+++ b/annotation-validator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.maven</groupId>

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -31,7 +31,7 @@ resources:
 pool:
   name: 'MDV-ADO-AGENT-AKS-01'
   demands:
-    - identifier -equals ubuntu-j21
+    - identifier -equals ubuntu-j25-postgres
  
 variables:
   - name: sonarqubeProject

--- a/domain-test-dsl/pom.xml
+++ b/domain-test-dsl/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>

--- a/framework-api/framework-api-aggregate-service/pom.xml
+++ b/framework-api/framework-api-aggregate-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-all/pom.xml
+++ b/framework-api/framework-api-all/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-common/pom.xml
+++ b/framework-api/framework-api-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-core/pom.xml
+++ b/framework-api/framework-api-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-direct-adapter/pom.xml
+++ b/framework-api/framework-api-direct-adapter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-domain/pom.xml
+++ b/framework-api/framework-api-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-event-buffer/pom.xml
+++ b/framework-api/framework-api-event-buffer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-event-source/pom.xml
+++ b/framework-api/framework-api-event-source/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-event-stream/pom.xml
+++ b/framework-api/framework-api-event-stream/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-healthcheck/pom.xml
+++ b/framework-api/framework-api-healthcheck/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-interceptors/framework-api-event-listener-interceptors/pom.xml
+++ b/framework-api/framework-api-interceptors/framework-api-event-listener-interceptors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api-interceptors</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-interceptors/pom.xml
+++ b/framework-api/framework-api-interceptors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-messaging-adapter/pom.xml
+++ b/framework-api/framework-api-messaging-adapter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-messaging-client/pom.xml
+++ b/framework-api/framework-api-messaging-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-messaging-jms/pom.xml
+++ b/framework-api/framework-api-messaging-jms/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-rest-adapter/pom.xml
+++ b/framework-api/framework-api-rest-adapter/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-rest-client/pom.xml
+++ b/framework-api/framework-api-rest-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-rest-core/pom.xml
+++ b/framework-api/framework-api-rest-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
    </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-subscription/pom.xml
+++ b/framework-api/framework-api-subscription/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-system/framework-api-system-errors/pom.xml
+++ b/framework-api/framework-api-system/framework-api-system-errors/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api-system</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-system/pom.xml
+++ b/framework-api/framework-api-system/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-unifiedsearch/pom.xml
+++ b/framework-api/framework-api-unifiedsearch/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/framework-api-validator/pom.xml
+++ b/framework-api/framework-api-validator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-api</artifactId>
         <groupId>uk.gov.justice.framework-api</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-api/pom.xml
+++ b/framework-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.framework-api</groupId>

--- a/framework-datasources/framework-datasource-providers/pom.xml
+++ b/framework-datasources/framework-datasource-providers/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-datasources</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework-datasource-providers</artifactId>

--- a/framework-datasources/framework-datasource-test-utils/pom.xml
+++ b/framework-datasources/framework-datasource-test-utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-datasources</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework-datasource-test-utils</artifactId>

--- a/framework-datasources/pom.xml
+++ b/framework-datasources/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework-datasources</artifactId>

--- a/framework-libraries-bom/pom.xml
+++ b/framework-libraries-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>framework-libraries</artifactId>
         <groupId>uk.gov.justice.framework.libraries</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-libraries-version/pom.xml
+++ b/framework-libraries-version/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>framework-libraries-version</artifactId>

--- a/framework-utilities/maven-test-utils/pom.xml
+++ b/framework-utilities/maven-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.utilities</groupId>
         <artifactId>framework-utilities</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-utilities/pom.xml
+++ b/framework-utilities/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.framework.utilities</groupId>

--- a/framework-utilities/test-utils/pom.xml
+++ b/framework-utilities/test-utils/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.utilities</groupId>
         <artifactId>framework-utilities</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.utils</groupId>

--- a/framework-utilities/test-utils/test-utils-core/pom.xml
+++ b/framework-utilities/test-utils/test-utils-core/pom.xml
@@ -7,22 +7,22 @@
     <parent>
         <groupId>uk.gov.justice.utils</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-utils-core</artifactId>
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.json</artifactId>
+            <groupId>org.eclipse.parsson</groupId>
+            <artifactId>parsson</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-client</artifactId>
         </dependency>
         <dependency>

--- a/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/compiler/JavaCompilerUtility.java
+++ b/framework-utilities/test-utils/test-utils-core/src/main/java/uk/gov/justice/services/test/utils/core/compiler/JavaCompilerUtility.java
@@ -1,22 +1,21 @@
 package uk.gov.justice.services.test.utils.core.compiler;
 
-import static com.google.common.collect.Sets.newHashSet;
 import static java.lang.String.join;
 import static java.text.MessageFormat.format;
 import static java.util.stream.Collectors.toSet;
-import static org.reflections.ReflectionUtils.forNames;
+import static org.reflections.scanners.Scanners.SubTypes;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import com.google.common.collect.Multimap;
 import org.reflections.Reflections;
-import org.reflections.scanners.SubTypesScanner;
+import org.reflections.util.ConfigurationBuilder;
 
 public class JavaCompilerUtility {
 
@@ -216,15 +215,28 @@ public class JavaCompilerUtility {
 
     private Set<Class<?>> loadClasses(final File compilationOutputDir, final String basePackage) {
         try (URLClassLoader resourceClassLoader = new URLClassLoader(new URL[]{compilationOutputDir.toURI().toURL()})) {
-            final Reflections reflections = new Reflections(basePackage, new SubTypesScanner(false), resourceClassLoader);
-            return newHashSet(forNames(getClassNames(reflections), resourceClassLoader));
+            final Reflections reflections = new Reflections(
+                    new ConfigurationBuilder()
+                            .forPackage(basePackage, resourceClassLoader)
+                            .addScanners(SubTypes.filterResultsBy(s -> true)));
+            return getClassNames(reflections).stream()
+                    .map(name -> loadClass(name, resourceClassLoader))
+                    .collect(toSet());
         } catch (IOException ex) {
             throw new CompilationException("Error creating class loader", ex);
         }
     }
 
     private Set<String> getClassNames(final Reflections reflections) {
-        Multimap<String, String> types = reflections.getStore().get(SubTypesScanner.class.getSimpleName());
-        return Stream.concat(types.values().stream(), types.keySet().stream()).collect(toSet());
+        final Map<String, Set<String>> types = reflections.getStore().get(SubTypes.index());
+        return Stream.concat(types.values().stream().flatMap(Set::stream), types.keySet().stream()).collect(toSet());
+    }
+
+    private static Class<?> loadClass(final String name, final ClassLoader classLoader) {
+        try {
+            return classLoader.loadClass(name);
+        } catch (ClassNotFoundException e) {
+            throw new CompilationException("Class not found: " + name, e);
+        }
     }
 }

--- a/framework-utilities/test-utils/test-utils-core/src/test/java/uk/gov/justice/services/test/utils/core/messaging/JsonObjectsTest.java
+++ b/framework-utilities/test-utils/test-utils-core/src/test/java/uk/gov/justice/services/test/utils/core/messaging/JsonObjectsTest.java
@@ -11,9 +11,10 @@ class JsonObjectsTest {
     @Test
     public void shouldJsonObjectsCacheProviders() {
         assertNotNull(jsonBuilderFactory);
-        assertTrue(jsonBuilderFactory.getConfigInUse().isEmpty());
+        // parsson returns null from getConfigInUse() when no config was set; glassfish returned empty map — both mean no config
+        assertTrue(jsonBuilderFactory.getConfigInUse() == null || jsonBuilderFactory.getConfigInUse().isEmpty());
         assertNotNull(jsonReaderFactory);
-        assertTrue(jsonReaderFactory.getConfigInUse().isEmpty());
+        assertTrue(jsonReaderFactory.getConfigInUse() == null || jsonReaderFactory.getConfigInUse().isEmpty());
     }
 
 }

--- a/framework-utilities/test-utils/test-utils-framework-api/pom.xml
+++ b/framework-utilities/test-utils/test-utils-framework-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.utils</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/framework-utilities/test-utils/test-utils-hibernate/pom.xml
+++ b/framework-utilities/test-utils/test-utils-hibernate/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.utils</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>test-utils-hibernate</artifactId>

--- a/framework-utilities/test-utils/test-utils-logging-jdk/pom.xml
+++ b/framework-utilities/test-utils/test-utils-logging-jdk/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.utils</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-utilities/test-utils/test-utils-logging-log4j/pom.xml
+++ b/framework-utilities/test-utils/test-utils-logging-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.utils</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-utilities/test-utils/test-utils-logging-simple/pom.xml
+++ b/framework-utilities/test-utils/test-utils-logging-simple/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.utils</groupId>
         <artifactId>test-utils</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/framework-utilities/utilities/pom.xml
+++ b/framework-utilities/utilities/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.utilities</groupId>
         <artifactId>framework-utilities</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.utils</groupId>

--- a/framework-utilities/utilities/utilities-core/pom.xml
+++ b/framework-utilities/utilities/utilities-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.utils</groupId>
         <artifactId>utilities</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>utilities-core</artifactId>

--- a/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/integerenum/IntegerEnumBeanDeserializerModifier.java
+++ b/framework-utilities/utilities/utilities-core/src/main/java/uk/gov/justice/services/common/converter/jackson/integerenum/IntegerEnumBeanDeserializerModifier.java
@@ -20,8 +20,8 @@ public class IntegerEnumBeanDeserializerModifier extends BeanDeserializerModifie
             final BeanDescription beanDesc,
             final JsonDeserializer<?> deserializer) {
 
-        final EnumResolver enumResolver = constructFor(config, beanDesc.getBeanClass());
-        final EnumResolver toStringResolver = constructUsingToString(config, beanDesc.getBeanClass());
+        final EnumResolver enumResolver = constructFor(config, beanDesc.getClassInfo());
+        final EnumResolver toStringResolver = constructUsingToString(config, beanDesc.getClassInfo());
 
         return new IntegerEnumDeserializer(
                 enumResolver,

--- a/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/messaging/JsonObjectsTest.java
+++ b/framework-utilities/utilities/utilities-core/src/test/java/uk/gov/justice/services/messaging/JsonObjectsTest.java
@@ -362,9 +362,9 @@ public class JsonObjectsTest {
     @Test
     public void shouldJsonObjectsCacheProviders() {
         assertNotNull(jsonBuilderFactory);
-        assertTrue(jsonBuilderFactory.getConfigInUse().isEmpty());
+        assertTrue(jsonBuilderFactory.getConfigInUse() == null || jsonBuilderFactory.getConfigInUse().isEmpty());
         assertNotNull(jsonReaderFactory);
-        assertTrue(jsonReaderFactory.getConfigInUse().isEmpty());
+        assertTrue(jsonReaderFactory.getConfigInUse() == null || jsonReaderFactory.getConfigInUse().isEmpty());
     }
 
     @Test
@@ -375,7 +375,7 @@ public class JsonObjectsTest {
 
         // then
         assertNotNull(first);
-        assertTrue(first.getConfigInUse().isEmpty());
+        assertTrue(first.getConfigInUse() == null || first.getConfigInUse().isEmpty());
         assertSame(first, second, "JsonReaderFactory should be a cached singleton instance");
     }
 
@@ -387,7 +387,7 @@ public class JsonObjectsTest {
 
         // then
         assertNotNull(first);
-        assertTrue(first.getConfigInUse().isEmpty());
+        assertTrue(first.getConfigInUse() == null || first.getConfigInUse().isEmpty());
         assertSame(first, second, "JsonWriterFactory should be a cached singleton instance");
     }
 
@@ -399,7 +399,7 @@ public class JsonObjectsTest {
 
         // then
         assertNotNull(first);
-        assertTrue(first.getConfigInUse().isEmpty());
+        assertTrue(first.getConfigInUse() == null || first.getConfigInUse().isEmpty());
         assertSame(first, second, "JsonBuilderFactory should be a cached singleton instance");
     }
 

--- a/generator-maven-plugin/files-for-testing-io/pom.xml
+++ b/generator-maven-plugin/files-for-testing-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator-maven-plugin/generator-core/pom.xml
+++ b/generator-maven-plugin/generator-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator-maven-plugin/generator-io-utils/pom.xml
+++ b/generator-maven-plugin/generator-io-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator-maven-plugin/generator-io-utils/src/main/java/uk/gov/justice/maven/generator/io/files/parser/io/FileTreeScanner.java
+++ b/generator-maven-plugin/generator-io-utils/src/main/java/uk/gov/justice/maven/generator/io/files/parser/io/FileTreeScanner.java
@@ -23,7 +23,7 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ResourceList;
 import io.github.classgraph.ScanResult;
 import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
+import org.reflections.scanners.Scanners;
 import org.reflections.util.ConfigurationBuilder;
 
 /**
@@ -68,7 +68,7 @@ public class FileTreeScanner {
                 new ConfigurationBuilder()
                         .filterInputsBy(filterOf(includes, excludes))
                         .setUrls(singletonList(baseDir.toUri().toURL()))
-                        .setScanners(new ResourcesScanner()));
+                        .setScanners(Scanners.Resources));
         return reflections.getResources(Pattern.compile(".*"));
     }
 

--- a/generator-maven-plugin/generator-maven-test-utils/pom.xml
+++ b/generator-maven-plugin/generator-maven-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator-maven-plugin/generator-plugin-it/pom.xml
+++ b/generator-maven-plugin/generator-plugin-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.maven.generator</groupId>
         <artifactId>generator-maven-plugin</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/generator-maven-plugin/generator-plugin/pom.xml
+++ b/generator-maven-plugin/generator-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.maven.generator</groupId>
         <artifactId>generator-maven-plugin</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>generator-plugin</artifactId>

--- a/generator-maven-plugin/generator-raml-parser/pom.xml
+++ b/generator-maven-plugin/generator-raml-parser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>generator-raml-parser</artifactId>

--- a/generator-maven-plugin/json-generator-for-testing-plugin/pom.xml
+++ b/generator-maven-plugin/json-generator-for-testing-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>json-generator-for-testing-plugin</artifactId>

--- a/generator-maven-plugin/parser-common/pom.xml
+++ b/generator-maven-plugin/parser-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator-maven-plugin/pom.xml
+++ b/generator-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.maven.generator</groupId>

--- a/generator-maven-plugin/raml-generator-for-testing-plugin/pom.xml
+++ b/generator-maven-plugin/raml-generator-for-testing-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator-maven-plugin/schema-parser/pom.xml
+++ b/generator-maven-plugin/schema-parser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>generator-maven-plugin</artifactId>
         <groupId>uk.gov.justice.maven.generator</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>schema-parser</artifactId>

--- a/job-manager/example/pom.xml
+++ b/job-manager/example/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>job-manager</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/job-manager/job-executor/pom.xml
+++ b/job-manager/job-executor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>job-manager</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/job-manager/job-manager-it/pom.xml
+++ b/job-manager/job-manager-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>job-manager</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/job-manager/jobstore-api/pom.xml
+++ b/job-manager/jobstore-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>job-manager</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/job-manager/jobstore-liquibase/pom.xml
+++ b/job-manager/jobstore-liquibase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 	    <groupId>uk.gov.justice.services</groupId>
         <artifactId>job-manager</artifactId>
-	    <version>21.0.0-M1-SNAPSHOT</version>
+	    <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobstore-liquibase</artifactId>

--- a/job-manager/jobstore-persistence/pom.xml
+++ b/job-manager/jobstore-persistence/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.services</groupId>
         <artifactId>job-manager</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>jobstore-persistence</artifactId>

--- a/job-manager/pom.xml
+++ b/job-manager/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.services</groupId>

--- a/json-schema-catalog/catalog-core/pom.xml
+++ b/json-schema-catalog/catalog-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/catalog-domain/pom.xml
+++ b/json-schema-catalog/catalog-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.schema</groupId>
         <artifactId>json-schema-catalog</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/catalog-effective-json-schema-generation/pom.xml
+++ b/json-schema-catalog/catalog-effective-json-schema-generation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/catalog-generation-plugin-it/pom.xml
+++ b/json-schema-catalog/catalog-generation-plugin-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/catalog-generation-plugin/pom.xml
+++ b/json-schema-catalog/catalog-generation-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/catalog-generation/pom.xml
+++ b/json-schema-catalog/catalog-generation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/catalog-integration-test/pom.xml
+++ b/json-schema-catalog/catalog-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/catalog-test-utils/pom.xml
+++ b/json-schema-catalog/catalog-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/json-schema-catalog/effective-json-schema-maven-plugin/pom.xml
+++ b/json-schema-catalog/effective-json-schema-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/effective-json-schema-plugin-it/pom.xml
+++ b/json-schema-catalog/effective-json-schema-plugin-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/pom.xml
+++ b/json-schema-catalog/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.schema</groupId>
     <artifactId>json-schema-catalog</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/json-schema-catalog/schema-example-context/example-integration-test/pom.xml
+++ b/json-schema-catalog/schema-example-context/example-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>schema-example-context</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/schema-example-context/pom.xml
+++ b/json-schema-catalog/schema-example-context/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/json-schema-catalog/schema-example-context/schema-example-command-api/pom.xml
+++ b/json-schema-catalog/schema-example-context/schema-example-command-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>schema-example-context</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/json-schema-catalog/schema-example-context/schema-example-standards/pom.xml
+++ b/json-schema-catalog/schema-example-context/schema-example-standards/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>schema-example-context</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-schema-catalog/schema-service/pom.xml
+++ b/json-schema-catalog/schema-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>json-schema-catalog</artifactId>
         <groupId>uk.gov.justice.schema</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-transformer/json-transformer-jolt/pom.xml
+++ b/json-transformer/json-transformer-jolt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.json</groupId>
         <artifactId>json-transformer</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/json-transformer/pom.xml
+++ b/json-transformer/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.json</groupId>

--- a/jsonschema-pojo-generator/example-pojo-schema/pom.xml
+++ b/jsonschema-pojo-generator/example-pojo-schema/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jsonschema-pojo-generator/example-schema-to-pojo-gen-test/pom.xml
+++ b/jsonschema-pojo-generator/example-schema-to-pojo-gen-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/jsonschema-pojo-generator/pojo-event-annotation-plugin/pom.xml
+++ b/jsonschema-pojo-generator/pojo-event-annotation-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jsonschema-pojo-generator/pojo-generation-core/pom.xml
+++ b/jsonschema-pojo-generator/pojo-generation-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jsonschema-pojo-generator/pojo-generation-plugin/pom.xml
+++ b/jsonschema-pojo-generator/pojo-generation-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jsonschema-pojo-generator/pojo-integration-test/pom.xml
+++ b/jsonschema-pojo-generator/pojo-integration-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jsonschema-pojo-generator/pojo-plugin-it/pom.xml
+++ b/jsonschema-pojo-generator/pojo-plugin-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/jsonschema-pojo-generator/pom.xml
+++ b/jsonschema-pojo-generator/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.generators</groupId>

--- a/jsonschema-pojo-generator/standard-test-catalog/pom.xml
+++ b/jsonschema-pojo-generator/standard-test-catalog/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>jsonschema-pojo-generator</artifactId>
         <groupId>uk.gov.justice.generators</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>21.0.0-M3</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>uk.gov.justice.framework.libraries</groupId>
     <artifactId>framework-libraries</artifactId>
-    <version>21.0.0-M1-SNAPSHOT</version>
+    <version>25.104.0-M1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Framework Common Libraries</name>
@@ -36,10 +36,10 @@
 
     <properties>
         <cpp.repo.name>framework-libraries</cpp.repo.name>
-        <maven-common-bom.version>21.0.0-M2</maven-common-bom.version>
+        <maven-common-bom.version>25.104.0-M1-SNAPSHOT</maven-common-bom.version>
         <cucumber.reporting.plugin.version>2.0.0</cucumber.reporting.plugin.version>
-        <framework-wiremock-service.version>21.0.0-M1-SNAPSHOT</framework-wiremock-service.version>
-        <file-service.version>21.0.0-M1-SNAPSHOT</file-service.version>
+        <framework-wiremock-service.version>25.104.0-M1-SNAPSHOT</framework-wiremock-service.version>
+        <file-service.version>25.104.0-M1-SNAPSHOT</file-service.version>
 
         <!-- Must be moved to parent-pom -->
         <maven-plugin-annotations.version>3.9.0</maven-plugin-annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>25.104.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -36,10 +36,10 @@
 
     <properties>
         <cpp.repo.name>framework-libraries</cpp.repo.name>
-        <maven-common-bom.version>25.104.0-M1-SNAPSHOT</maven-common-bom.version>
+        <maven-common-bom.version>25.104.0-M2</maven-common-bom.version>
         <cucumber.reporting.plugin.version>2.0.0</cucumber.reporting.plugin.version>
-        <framework-wiremock-service.version>25.104.0-M1-SNAPSHOT</framework-wiremock-service.version>
-        <file-service.version>25.104.0-M1-SNAPSHOT</file-service.version>
+        <framework-wiremock-service.version>25.104.0-M3</framework-wiremock-service.version>
+        <file-service.version>25.104.0-M3</file-service.version>
 
         <!-- Must be moved to parent-pom -->
         <maven-plugin-annotations.version>3.9.0</maven-plugin-annotations.version>

--- a/raml-maven/lint-checker-core/pom.xml
+++ b/raml-maven/lint-checker-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>raml-maven</artifactId>
         <groupId>uk.gov.justice.maven</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/raml-maven/pom.xml
+++ b/raml-maven/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework.libraries</groupId>
         <artifactId>framework-libraries</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.maven</groupId>

--- a/raml-maven/raml-for-testing-io/pom.xml
+++ b/raml-maven/raml-for-testing-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>raml-maven</artifactId>
         <groupId>uk.gov.justice.maven</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/raml-maven/raml-generator-core/pom.xml
+++ b/raml-maven/raml-generator-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>raml-maven</artifactId>
         <groupId>uk.gov.justice.maven</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/raml-maven/raml-generator-for-testing/pom.xml
+++ b/raml-maven/raml-generator-for-testing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>raml-maven</artifactId>
         <groupId>uk.gov.justice.maven</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/raml-maven/raml-maven-io-utils/pom.xml
+++ b/raml-maven/raml-maven-io-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>raml-maven</artifactId>
         <groupId>uk.gov.justice.maven</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/raml-maven/raml-maven-io-utils/src/main/java/uk/gov/justice/raml/io/FileTreeScanner.java
+++ b/raml-maven/raml-maven-io-utils/src/main/java/uk/gov/justice/raml/io/FileTreeScanner.java
@@ -23,7 +23,7 @@ import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ResourceList;
 import io.github.classgraph.ScanResult;
 import org.reflections.Reflections;
-import org.reflections.scanners.ResourcesScanner;
+import org.reflections.scanners.Scanners;
 import org.reflections.util.ConfigurationBuilder;
 
 /**
@@ -68,7 +68,7 @@ public class FileTreeScanner {
                 new ConfigurationBuilder()
                         .filterInputsBy(filterOf(includes, excludes))
                         .setUrls(singletonList(baseDir.toUri().toURL()))
-                        .setScanners(new ResourcesScanner()));
+                        .setScanners(Scanners.Resources));
         return reflections.getResources(Pattern.compile(".*"));
     }
 

--- a/raml-maven/raml-maven-plugin-it/pom.xml
+++ b/raml-maven/raml-maven-plugin-it/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.maven</groupId>
         <artifactId>raml-maven</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/raml-maven/raml-maven-plugin/pom.xml
+++ b/raml-maven/raml-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>uk.gov.justice.maven</groupId>
         <artifactId>raml-maven</artifactId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <artifactId>raml-maven-plugin</artifactId>

--- a/raml-maven/raml-parser/pom.xml
+++ b/raml-maven/raml-parser/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>raml-maven</artifactId>
         <groupId>uk.gov.justice.maven</groupId>
-        <version>21.0.0-M1-SNAPSHOT</version>
+        <version>25.104.0-M1-SNAPSHOT</version>
     </parent>
 
     <!-- TODO: this name conflicts with an artifact name in generator-maven-plugin. -->


### PR DESCRIPTION
## Java 25 / WildFly 40 spike — cp-framework-libraries

Spike to prove viability of skipping Java 21 and going straight to **Java 25 / WildFly 40 / Jakarta EE 11**.

**Spike gate: cp-cake-shop integration tests — 42/42 passing ✅**

Version series: `25.104.0-M1-SNAPSHOT` — the middle number preserves the framework-E lineage (104), 25 = Java version.

### Changes
- Version bumped to `25.104.0-M1-SNAPSHOT`
- All module parent versions updated to `cp-maven-framework-parent-pom:25.104.0-M1-SNAPSHOT`
- `maven-plugin-plugin` pinned to `3.15.2` — uses ASM 9.9 which supports Java 25 bytecode analysis (earlier versions fail with unsupported class file major version 69)
- `jakarta.xml.bind-api` pinned to `2.3.2` in RAML generator plugin dependencies (resolves plugin classpath conflict)
- Test scope: `org.glassfish:jakarta.json` replaced with `org.eclipse.parsson:parsson` (glassfish artifact unavailable in Jakarta EE 11)

### ⚠️ CI
CIs will fail until Java 25 build pipelines are created. **Do not merge until CI is green.**

### Related PRs (full spike chain)
cp-maven-super-pom → cp-maven-parent-pom → cp-maven-common-bom → cp-maven-framework-parent-pom → cp-file-service → cp-wiremock-service → cp-framework-libraries → cp-microservice-framework → cp-event-store → cp-cake-shop