### PR TITLE
Remove stale maven-plugin-annotations.version=3.9.0 override

### DIFF
--- a/annotation-validator/annotation-validator-maven-plugin/pom.xml
+++ b/annotation-validator/annotation-validator-maven-plugin/pom.xml
@@ -17,7 +17,6 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
             <scope>provided</scope>
-            <version>${maven-plugin-annotations.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,6 @@
         <framework-wiremock-service.version>25.104.0-M3</framework-wiremock-service.version>
         <file-service.version>25.104.0-M3</file-service.version>
 
-        <!-- Must be moved to parent-pom -->
-        <maven-plugin-annotations.version>3.9.0</maven-plugin-annotations.version>
-
         <!--
             jakarta.xml.bind:jakarta.xml.bind-api is managed by the BOM at 4.0.0 (Jakarta EE 10,
             jakarta.* namespace). However, org.raml:raml-parser is a legacy third-party library


### PR DESCRIPTION
## Summary

- Removes `maven-plugin-annotations.version=3.9.0` from the root pom. The BOM (`cp-maven-common-bom`) already manages `maven-plugin-annotations` at 3.15.2; the local property was silently overriding it with an older version. The comment in the pom even noted "Must be moved to parent-pom" — this was a recognised stale entry
- Removes the corresponding explicit `<version>${maven-plugin-annotations.version}</version>` from `annotation-validator-maven-plugin/pom.xml` so the BOM manages the version

## Test plan

- [ ] Key plugin modules build: `mvn clean install -pl annotation-validator/annotation-validator-maven-plugin,generator-maven-plugin/generator-plugin,raml-maven/raml-maven-plugin -am` — all pass
- [ ] CI passes (pre-existing `maven-jar-plugin` empty-source failures in IT/testing utility modules are unrelated to this change)