### PR TITLE
Remove liquibase.hub.mode property removed in Liquibase 4.12.0

### DIFF
--- a/job-manager/jobstore-liquibase/src/main/resources/liquibase.properties
+++ b/job-manager/jobstore-liquibase/src/main/resources/liquibase.properties
@@ -1,5 +1,4 @@
 changelog-file: liquibase/jobstore-db-changelog.xml
-liquibase.hub.mode: off
 liquibase.headless: true
 
 # Stop liquibase collecting anonymous analytics should we ever upgrade to liquibase 4.30.0 or greater


### PR DESCRIPTION
## Summary

- `jobstore-liquibase.jar` bundles Liquibase 4.27.0; the other Liquibase JARs in the material-service image bundle 4.10.0
- `liquibase.hub.mode` was removed in Liquibase 4.12.0 — 4.27.0's strict checking rejects it as an unknown key and exits non-zero
- The Kubernetes pre-install hook script does not `exit` on step failure, so the pod keeps running until the 900-second Helm timeout fires
- Steps 1–4 (event-store, snapshot-store, event-buffer, event-tracking) succeeded; step 5 (jobstore) failed silently causing the `material-service-wildfly-app-liquibase-job` timeout

## Fix

Remove the single offending line from `jobstore-liquibase/src/main/resources/liquibase.properties`.

## Test plan

- [ ] Confirm `jobstore-liquibase.jar` builds cleanly (`mvn clean install -pl job-manager/jobstore-liquibase`)
- [ ] Re-run `team/25.104.x` pipeline on `cpp-context-material` and confirm the Liquibase pre-install job completes